### PR TITLE
Modified reward functions and data locality score

### DIFF
--- a/other_agents.py
+++ b/other_agents.py
@@ -13,8 +13,6 @@ def get_packer_action(machines, job_slot):
                 if can_allocate: # enough resource to allocate
                     idx_of_res_alloc = [[] for i in range(machines.num_machines)] ##list of resource indices to be allocated per machine
 
-                    threshold_score = (machines.num_machines - 1) ** 2 * machines.num_res / 4
-
                     current_minimum_score = 0.0
                     current_minimum_combination = []
 
@@ -25,8 +23,9 @@ def get_packer_action(machines, job_slot):
                             tmp_score += (tmp[machine_idx] - tmp[0]) ** 2
                         # print tmp, tmp_score
                         # current_minimum_combination = list(tmp)
-                        if tmp_score <= threshold_score:
+                        if tmp_score <= machines.data_locality_threshold:
                             current_minimum_combination = list(tmp)
+                            current_minimum_score = tmp_score
                             break
                         else:
                             if tmp_score <= current_minimum_score:
@@ -34,6 +33,7 @@ def get_packer_action(machines, job_slot):
                                 current_minimum_score = tmp_score
 
                     # print current_minimum_combination
+                    new_job.data_locality_score = current_minimum_score
 
                     for res_idx, machine_idx in enumerate(current_minimum_combination):
                         idx_of_res_alloc[machine_idx].append(res_idx)
@@ -84,8 +84,6 @@ def get_packer_sjf_action(machines, job_slot, knob):  # knob controls which to f
                 if can_allocate: # enough resource to allocate
                     idx_of_res_alloc = [[] for i in range(machines.num_machines)] ##list of resource indices to be allocated per machine
 
-                    threshold_score = (machines.num_machines - 1) ** 2 * machines.num_res / 4
-
                     current_minimum_score = 0.0
                     current_minimum_combination = []
 
@@ -96,8 +94,9 @@ def get_packer_sjf_action(machines, job_slot, knob):  # knob controls which to f
                             tmp_score += (tmp[machine_idx] - tmp[0]) ** 2
                         # print tmp, tmp_score
                         # current_minimum_combination = list(tmp)
-                        if tmp_score <= threshold_score:
+                        if tmp_score <= machines.data_locality_threshold:
                             current_minimum_combination = list(tmp)
+                            current_minimum_score = tmp_score
                             break
                         else:
                             if tmp_score <= current_minimum_score:
@@ -105,6 +104,7 @@ def get_packer_sjf_action(machines, job_slot, knob):  # knob controls which to f
                                 current_minimum_score = tmp_score
 
                     # print current_minimum_combination
+                    new_job.data_locality_score = current_minimum_score
 
                     for res_idx, machine_idx in enumerate(current_minimum_combination):
                         idx_of_res_alloc[machine_idx].append(res_idx)

--- a/parameters.py
+++ b/parameters.py
@@ -58,6 +58,7 @@ class Parameters:
         self.delay_penalty = -1       # penalty for delaying things in the current work screen
         self.hold_penalty = -1        # penalty for holding things in the new work screen
         self.dismiss_penalty = -1     # penalty for missing a job because the queue is full
+        self.locality_penalty = -1    # penalty for data locality score
 
         self.num_frames = 1           # number of frames to combine and process
         self.lr_rate = 0.001          # learning rate


### PR DESCRIPTION
- Modifications
  1. Now data locality score threshold is a member of the class `MultiMachines` -> `MultiMachines.data_locality_threshold`, as we may need to reuse this variable in `other_agents`.
  2. Added data locality penalty: `Parameters.locality_penalty`. In the function of `get_reward`, it's calculated on data locality score and job length.

- Problems
  I have tested it and seems working well. But currently, we may have too many machines for the original job distribution. When testing our algorithm in the test mode, it has identical performance to SJF. We may need to change job distribution to generate more jobs with longer running time and more required resources to make some difference.