### PR TITLE
fix: data locality score threshold & print out results

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -458,7 +458,12 @@ class MultiMachines:
         self.num_machines = pa.num_machines
 
         # Reduced data locality threshold
-        self.data_locality_threshold = (self.num_machines - 1) ** 2 * self.num_res / 16
+        self.data_locality_threshold = 0.0
+
+        if (self.num_machines - 1) ** 2 * self.num_res / 16 > 1.0:
+            self.data_locality_threshold = (self.num_machines - 1) ** 2 * self.num_res / 16 
+        else:
+            self.data_locality_threshold = 1.0
 
         self.machinelist = []
         self.running_job = []

--- a/get_res.py
+++ b/get_res.py
@@ -1,6 +1,9 @@
 import os
 import matplotlib.pyplot as plt
 
+SJF_slowdown = 4.0
+Random_slowdown = 8.0
+
 target_path = 'test'
 file_names = [f for f in os.listdir(target_path) if os.path.isfile(os.path.join(target_path, f))]
 file_names.sort(key=lambda l: os.path.getmtime(os.path.join(target_path, l)))
@@ -16,16 +19,20 @@ for file_name in file_names:
     f.close()
 
 plt.plot(list(range(0, len(mean_slowdown))), mean_slowdown, label='DeepRM', c='blue')
-
+plt.plot(list(range(0, len(mean_slowdown))), [SJF_slowdown]*len(mean_slowdown), label='SJF', c='green', linestyle='dashed')
+plt.plot(list(range(0, len(mean_slowdown))), [Random_slowdown]*len(mean_slowdown), label='Random', c='black', linestyle='dashed')
+plt.legend(loc='best')
 plt.xlabel('Iteration')
 plt.ylabel('Average slowdown')
-# plt.show()
+plt.xlim(0, len(mean_slowdown))
+plt.show()
 plt.savefig('slowdown.png', format='png')
 
 plt.close()
 plt.plot(list(range(0, len(mean_rewards))), mean_rewards, label='DeepRM Mean', c='blue')
 plt.plot(list(range(0, len(max_rewards))), max_rewards, label='DeepRM Max', c='red')
 plt.legend(loc='best')
+plt.xlim(0, len(mean_slowdown))
 plt.xlabel('Iteration')
 plt.ylabel('Total reward')
 plt.savefig('reward.png', format='png')

--- a/get_res.py
+++ b/get_res.py
@@ -1,0 +1,32 @@
+import os
+import matplotlib.pyplot as plt
+
+target_path = 'test'
+file_names = [f for f in os.listdir(target_path) if os.path.isfile(os.path.join(target_path, f))]
+file_names.sort(key=lambda l: os.path.getmtime(os.path.join(target_path, l)))
+
+max_rewards, mean_rewards, mean_slowdown = [], [], []
+
+for file_name in file_names:
+    with open(os.path.join(target_path, file_name)) as f:
+        lines = [line.rstrip().split(' ') for line in f.readlines()]
+        max_rewards.append(lines[4][2])
+        mean_rewards.append(lines[5][2])
+        mean_slowdown.append(lines[6][2])
+    f.close()
+
+plt.plot(list(range(0, len(mean_slowdown))), mean_slowdown, label='DeepRM', c='blue')
+
+plt.xlabel('Iteration')
+plt.ylabel('Average slowdown')
+# plt.show()
+plt.savefig('slowdown.png', format='png')
+
+plt.close()
+plt.plot(list(range(0, len(mean_rewards))), mean_rewards, label='DeepRM Mean', c='blue')
+plt.plot(list(range(0, len(max_rewards))), max_rewards, label='DeepRM Max', c='red')
+plt.legend(loc='best')
+plt.xlabel('Iteration')
+plt.ylabel('Total reward')
+plt.savefig('reward.png', format='png')
+# plt.show()


### PR DESCRIPTION
- Fixed data locality score threshold, make it has a minimum of `1.0`, or it will just assign jobs in one machine when the amount of machine is too small.
- Modified `slow_down_cdf.py`, now it can print out the average of`slowdown`, `completion time`, 'data locality score'
- Questions on agents. Add `packer` to `test_type`, but not sure whether using a correct agent